### PR TITLE
Fix possible XSS when label contains javascript

### DIFF
--- a/fSelect.js
+++ b/fSelect.js
@@ -103,7 +103,7 @@
                 var labelText = [];
 
                 this.$wrap.find('.fs-option.selected').each(function(i, el) {
-                    labelText.push($(el).find('.fs-option-label').text());
+                    labelText.push($(el).find('.fs-option-label').html());
                 });
 
                 if (labelText.length < 1) {


### PR DESCRIPTION
Options labels that come from users are not safe. The text from the labels is executed as code even if the code is escaped. The code is executed when you select only the option containing code.

```html
<select class="my-select-box" multiple="multiple">
    <optgroup label="Northeast">
        <option value="me">Maine</option>
        <option value="asd">&lt;script&gt;alert('x');&lt;/script&gt;</option>
</select>
```
https://jsfiddle.net/r0pw7g11/133/

This PR uses .html() to take the html code used in the label element so it should preserve any HTML and escapes. Alternatively could use .text to place the text into the html to escape the html from the text.